### PR TITLE
Added in functionality to allow request to choose the number of jokes generated

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@
 
 [https://official-joke-api.appspot.com/jokes/random](https://official-joke-api.appspot.com/jokes/random)
 
+### Grab your number choice of random jokes!
+[https://official-joke-api.appspot.com/jokes/random/10](http://official-joke-api.appspot.com/jokes/random/10)
+Replace 10 with your choices number. For example, for 50 random jokes, go to:
+[https://official-joke-api.appspot.com/jokes/random/50](http://official-joke-api.appspot.com/jokes/random/50)
+
+The number may not go over the number of jokes that are available inside the jokes API. In that scenario the request will be an error.
+
 ### Grab ten random jokes!
 [https://official-joke-api.appspot.com/random_ten](https://official-joke-api.appspot.com/random_ten)
 

--- a/handler.js
+++ b/handler.js
@@ -25,8 +25,10 @@ const randomN = (jokeArray, n) => {
 
 const randomTen = () => randomN(jokes, 10);
 
+const randomSelect = (number) => randomN(jokes, number);
+
 const jokeByType = (type, n) => {
   return randomN(jokes.filter(joke => joke.type === type), n);
 };
 
-module.exports = { jokes, randomJoke, randomN, randomTen, jokeByType };
+module.exports = { jokes, randomJoke, randomN, randomTen, jokeByType, randomSelect };

--- a/index.js
+++ b/index.js
@@ -32,14 +32,17 @@ app.get('/jokes/random', (req, res) => {
 });
 
 app.get("/jokes/random(/*)?", (req, res) => {
+  let num;
+
   try {
-    var num = parseInt(req.path.substring(14, req.path.length));
+    num = parseInt(req.path.substring(14, req.path.length));
   } catch (err) {
-    res.send("The path passed is not a number.");
+    res.send("The passed path is not a number.");
   } finally {
-    var count = Object.keys(jokes).length;
-    if (num > count) {
-      res.send("That is a way to large amount of jokes.");
+    const count = Object.keys(jokes).length;
+
+    if (num > Object.keys(jokes).length) {
+      res.send(`The passed path exceeds the number of jokes (${count}).`);
     } else {
       res.json(randomSelect(num));
     }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const LimitingMiddleware = require('limiting-middleware');
-const { randomJoke, randomTen, jokeByType } = require('./handler');
+const { jokes, randomJoke, randomTen, jokeByType, randomSelect } = require('./handler');
 
 const app = express();
 
@@ -29,6 +29,21 @@ app.get('/random_ten', (req, res) => {
 
 app.get('/jokes/random', (req, res) => {
   res.json(randomJoke());
+});
+
+app.get("/jokes/random(/*)?", (req, res) => {
+  try {
+    var num = parseInt(req.path.substring(14, req.path.length));
+  } catch (err) {
+    res.send("The path passed is not a number.");
+  } finally {
+    var count = Object.keys(jokes).length;
+    if (num > count) {
+      res.send("That is a way to large amount of jokes.");
+    } else {
+      res.json(randomSelect(num));
+    }
+  }
 });
 
 app.get('/jokes/ten', (req, res) => {


### PR DESCRIPTION
Updates:
- Added in any number of random number of jokes inside the request
- Adjusted README.md

Technical Details:
The README.md was edited to include the underneath functionality.

I also added the functionality of specifying the random number of jokes you want. Unfortunately this functionality does not allow you to go to specify the type. This functionality was build using Express.js's   ability to match relative paths to wildcards. To get a specified random number of jokes navigate to the following relative path:
/jokes/random/{your number here}
Replace the {your number here} with your specified number. The number must be an integer and must not be over the the number of jokes or an error is returned. The original functionality of the default number    being 1 if there is no number specified is still there. To make this functionality I created a function in the handler.js which returns the random jokes given the num argument. The function was added into the   exports. It was also imported in the index.js. Next, I added a get method into the express application listening for a wildcard that represented by the above relative path. Next, I used substring to take in the number and parse it as an INT. This is where exceptional handling is used to return an error if the string can't be parsed. In the except clause, the error is returned. In the finally clause, it checks whether  the number is too long compared to the number of jokes and returns an error if so. If not then the application returns the jokes. The JSON of the jokes also had to be accessed by exporting it in the handler.js  and importing it in the index.js. It had to be accessed to get the number of jokes to see if a error has to be returned.