### PR TITLE
fixed at typoo

### DIFF
--- a/jokes/index.json
+++ b/jokes/index.json
@@ -1837,7 +1837,7 @@
   {
     "type": "programming",
     "setup": "There are 10 kinds of people in this world.",
-    "punchline": "Those who understand binary, those who don't, and those who weren't expecting a base 3 joke."
+    "punchline": "Those who understand binary, those who don't, and those who weren't expecting a base 2 joke."
   },
   {
     "type": "general",


### PR DESCRIPTION
 it was supposed to be " base 2 joke" not "base 3".